### PR TITLE
squelch c compiler warnings

### DIFF
--- a/src/c/TLE.c
+++ b/src/c/TLE.c
@@ -15,7 +15,6 @@ static void setValsToRec(TLE *tle, ElsetRec *rec);
 
 void parseLines(TLE *tle, char *line1, char *line2)
 {
-    int i=0;
     tle->rec.whichconst=wgs72;
     // copy the lines
     strncpy(tle->line1,line1,69);
@@ -65,7 +64,7 @@ void parseLines(TLE *tle, char *line1, char *line2)
     setValsToRec(tle, &tle->rec);
 }
 
-bool isLeap(int year)
+static bool isLeap(int year)
 {
     if(year % 4 != 0)
     {
@@ -118,7 +117,6 @@ long parseEpoch(ElsetRec *rec, char *str)
     strncpy(&tmp2[1],&tmp[5],9);
     tmp2[11]=0;
     double dfrac = strtod(tmp2,NULL);
-    double odfrac = dfrac;
     rec->epochdays = doy;
     rec->epochdays += dfrac;
 
@@ -133,7 +131,6 @@ long parseEpoch(ElsetRec *rec, char *str)
 
 
     dfrac = 1000.0*(dfrac-sc);
-    int milli = (int)dfrac;
 
     double sec = ((double)sc)+dfrac/1000.0;
 
@@ -208,7 +205,7 @@ void setValsToRec(TLE *tle, ElsetRec *rec)
 
     rec->elnum = tle->elnum;
     rec->revnum = tle->revnum;
-    strncpy(rec->satid,tle->objectID,5);
+    memcpy(rec->satid,tle->objectID,6);
     //rec->satnum = tle->objectNum;
     rec->bstar = tle->bstar;
     rec->inclo = tle->incDeg*deg2rad;


### PR DESCRIPTION
* remove unused variables (-Wunused-variable)
* make isLeap static (-Wmissing-prototypes)
* replace strncpy with memcpy (-Wstringop-truncation)